### PR TITLE
Add downloader tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The scraper is configured to extract 12 products (within the 10-15 range specifi
 
 ### Testes
 ```bash
-python test_scraper.py
+pytest
 ```
 
 ## Architecture
@@ -218,7 +218,7 @@ src/
 └── downloader.py    # Asset downloads
 
 tests/
-├── test_scraper.py  # Basic functionality tests
+├── test_downloader.py  # Unit tests
 └── demo_output.py   # Output demonstration
 
 output/               # Generated during execution

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -130,15 +130,20 @@ def get_file_extension(url):
     if ext and len(ext) <= 5:  # Extensão válida (.pdf, .dwg, etc.)
         return ext.lower()
     
-    # Extensões comuns baseadas no tipo de asset
+    # Extensões comuns baseadas em palavras-chave
     common_extensions = {
         'manual': '.pdf',
         'cad': '.dwg',
         'image': '.jpg',
         'datasheet': '.pdf',
-        'certificate': '.pdf'
+        'certificate': '.pdf',
     }
-    
+
+    lower_url = (url_path + urlparse(url).query).lower()
+    for key, default_ext in common_extensions.items():
+        if key in lower_url:
+            return default_ext
+
     # Se não conseguiu determinar, usa .bin como padrão
     return '.bin'
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.downloader import sanitize_filename, get_file_extension
+
+
+def test_sanitize_filename_replaces_invalid_chars():
+    original = 'bad<name>:with|chars?*'
+    sanitized = sanitize_filename(original)
+    assert sanitized == 'bad_name__with_chars__'
+    for ch in '<>:"/\\|?*':
+        assert ch not in sanitized
+
+
+def test_get_file_extension_from_url():
+    url = 'https://example.com/files/document.pdf'
+    assert get_file_extension(url) == '.pdf'
+
+
+def test_get_file_extension_extensionless_manual():
+    url = 'https://example.com/downloads/manual'
+    assert get_file_extension(url) == '.pdf'
+
+
+def test_get_file_extension_extensionless_cad():
+    url = 'https://example.com/assets/cad/model'
+    assert get_file_extension(url) == '.dwg'
+
+
+
+
+def test_get_file_extension_extensionless_image():
+    url = 'https://example.com/view/image'
+    assert get_file_extension(url) == '.jpg'
+
+
+def test_get_file_extension_unknown_returns_bin():
+    url = 'https://example.com/downloads/unknown'
+    assert get_file_extension(url) == '.bin'
+
+
+def test_sanitize_filename_empty_returns_unnamed():
+    assert sanitize_filename('') == 'unnamed'


### PR DESCRIPTION
## Summary
- add unit tests covering sanitize_filename and get_file_extension
- enhance get_file_extension to infer extension from keywords
- document running tests with pytest
- fix newline at end of README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684357de47c88326ad296b93d2f5003f